### PR TITLE
Add MacOS ci

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,19 +22,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-      
-    - name: Query git revision
-      id: git_revision
-      shell: bash
-      run: |
-        GITREV="`git show -s --format='%h'`"
-        echo "::set-output name=revision::${GITREV}"
     
     - name: Set up cache
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ${{ runner.os }}-cache-${{ steps.git_revision.outputs.revision }}
+        key: ${{ runner.os }}-cache-${{ github.sha }}
         restore-keys: ${{ runner.os }}-cache-
     
     - name: Configure CMake
@@ -54,3 +47,28 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -VV -C ${{env.BUILD_TYPE}}      
+
+  macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: |
+        brew install llvm || true
+        cmake -B ${{github.workspace}}/build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTING=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -VV -C ${{env.BUILD_TYPE}}   

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Project for System and Device Programming course at Politecnico di Torino
 `tests` runs automated tests against the included example graphs.
 
 ## Platform compatibility
-The program has been built and tested on Windows and Linux environments.
+The program has been built and tested on Windows, Linux and MacOS environments.
 Compilers used were MSVC 2019, GCC 9.3.0 and Clang 12.0.1 .
+Building and testing on MacOS has been done solely based on CI.
 
 ## Build instructions
 ### Windows

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Project for System and Device Programming course at Politecnico di Torino
 
 ## Platform compatibility
 The program has been built and tested on Windows and Linux environments.
-Compilers used were MSVC 2019, GCC 9.3.0 and Clang.
-No testing has been done on MacOS environments.
+Compilers used were MSVC 2019, GCC 9.3.0 and Clang 12.0.1 .
 
 ## Build instructions
 ### Windows


### PR DESCRIPTION
Add a MacOS CI check using llvm's clang compiler.
The clang c++20 implementation status is still partial, but seems like it covers what's used here.